### PR TITLE
[Fix/#80] 대시보드 본문 영역이 길어지면 사이드바가 잘려보이는 현상 처리

### DIFF
--- a/src/features/dashboards/components/layout/index.tsx
+++ b/src/features/dashboards/components/layout/index.tsx
@@ -12,9 +12,9 @@ import { Outlet } from 'react-router-dom';
  */
 export default function DashboardLayout() {
   return (
-    <div className="flex min-h-screen w-full overflow-x-auto bg-gray-50">
+    <div className="flex h-screen overflow-hidden bg-gray-50">
       <Sidebar />
-      <div className="flex flex-1 flex-col">
+      <div className="flex min-w-0 flex-1 flex-col">
         <Header />
         <main className="flex-1 overflow-auto">
           <Outlet />


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #80 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> * 대시보드 본문 영역이 길어져도 사이드바는 항상 고정되도록 메인레이아웃 index.tsx 파일 수정

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
