### PR TITLE
[Fix/#203] 헤더 아바타 그룹 로드 안되는 문제 해결

### DIFF
--- a/src/features/dashboards/components/layout/index.tsx
+++ b/src/features/dashboards/components/layout/index.tsx
@@ -24,12 +24,12 @@ import { getDashboard } from '@/features/dashboards/apis/getDashboard';
 export default function DashboardLayout() {
   const location = useLocation();
   const navigate = useNavigate();
-  const { id } = useParams<{ id: string }>();
+  const { id: dashboardId } = useParams<{ id: string }>();
   const {
     members: dashboardMembers,
     totalCount,
     errorMessage: memberLoadError,
-  } = useDashboardMembers(id);
+  } = useDashboardMembers(dashboardId);
   const {
     isOpen: isInviteModalOpen,
     openModal: handleOpenInviteModal,
@@ -61,15 +61,15 @@ export default function DashboardLayout() {
   } | null>(null);
 
   const handleNavigateDashboardEdit = () => {
-    if (!id) {
+    if (!dashboardId) {
       return;
     }
 
-    navigate(`/dashboard/${id}/edit`);
+    navigate(`/dashboard/${dashboardId}/edit`);
   };
 
   const handleOpenDashboardInviteModal = () => {
-    if (!id) {
+    if (!dashboardId) {
       return;
     }
 
@@ -86,7 +86,7 @@ export default function DashboardLayout() {
 
   // Layout에서 id가 바뀔 때마다 직접 대시보드 정보 조회
   useEffect(() => {
-    if (!id || isMyDashboardPage || isMyPage) return;
+    if (!dashboardId || isMyDashboardPage || isMyPage) return;
 
     async function fetchTitle(dashboardId: string) {
       const data = await getDashboard(dashboardId);
@@ -99,8 +99,8 @@ export default function DashboardLayout() {
       }
     }
 
-    fetchTitle(id);
-  }, [id, isMyDashboardPage, isMyPage]);
+    fetchTitle(dashboardId);
+  }, [dashboardId, isMyDashboardPage, isMyPage]);
 
   // 대시보드 제목 변경 이벤트 수신
   useEffect(() => {
@@ -108,7 +108,7 @@ export default function DashboardLayout() {
       const { title: newTitle } = (
         event as CustomEvent<DashboardTitleChangeDetail>
       ).detail;
-      if (id) {
+      if (dashboardId) {
         setDashboardInfo((previousDashboardInfo) => {
           if (!previousDashboardInfo) {
             return previousDashboardInfo;
@@ -130,7 +130,7 @@ export default function DashboardLayout() {
         handleTitleChange
       );
     };
-  }, [id]);
+  }, [dashboardId]);
 
   return (
     <>
@@ -156,7 +156,7 @@ export default function DashboardLayout() {
                 ? '내 대시보드'
                 : isMyPage
                   ? '계정관리'
-                  : dashboardInfo?.id === id
+                  : dashboardInfo?.id === dashboardId
                     ? dashboardInfo?.title
                     : ''
             }


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #203 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

**문제:** 
useDashboardMembers 훅을 호출할 때 현재 대시보드 ID(dashboardId)를 전달하지 않아서 API 요청이 아예 실행되지 않고, 결과적으로 Header가 members를 빈 배열로 받아옴

**해결:** 
대시보드ID 전달해서 헤더 멤버 아바타가 로드가 됨

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
