### PR TITLE
[Fix/#241] 화면 접속 및 새로고침 시 프로필 데이터 초기화

### DIFF
--- a/src/features/dashboards/components/layout/dashboard-header/index.tsx
+++ b/src/features/dashboards/components/layout/dashboard-header/index.tsx
@@ -53,7 +53,7 @@ export default function Header({
   return (
     <header className="z-header flex h-15 min-w-0 items-center justify-between border-b border-gray-200 bg-white pl-4 md:h-17.5 md:px-10 lg:justify-between">
       {/* 제목 - 데스크탑에서만 표시 */}
-      {isTitleVisible && (
+      {isTitleVisible && title && (
         <div
           className={
             isTitleAlwaysVisible


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #241 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 화면 접속 시 기본적으로 보이던 배유철 데이터와, 보라색 기본 프로필 이미지 배경을 표시되지 않도록 처리

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
