### PR TITLE
[Feat/#244] 초대취소 모달에 취소 버튼만 두개 표시되는 문제 처리

### DIFF
--- a/src/features/invitations/components/invitations-section/index.tsx
+++ b/src/features/invitations/components/invitations-section/index.tsx
@@ -220,7 +220,7 @@ export default function InvitationsSection() {
             <span className="text-error">취소</span> 하시겠습니까?
           </>
         }
-        confirmText="취소"
+        confirmText="확인"
       />
     </section>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #244 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 초대취소 모달에 '취소' 버튼만 두개가 표시되는 현상을 '확인' 버튼으로 변경하여 처리
> <img width="586" height="197" alt="image" src="https://github.com/user-attachments/assets/4e7397ed-3d80-417b-aeed-4d0889658416" />


### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
