### PR TITLE
[Fix/#240] 중복 초대 에러 처리

### DIFF
--- a/src/features/invitations/components/invitations-section/invite-modal/index.tsx
+++ b/src/features/invitations/components/invitations-section/invite-modal/index.tsx
@@ -50,7 +50,7 @@ export default function InviteModal({
       let page = 1;
       while (isMounted) {
         const data = await getInvitations(safeDashboardId, page);
-        if (!data) break;
+        if (!isMounted || !data) break;
 
         for (const invitation of data.invitations) {
           collectedEmails.add(invitation.invitee.email.toLowerCase());


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #240 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- InviteModal에서 getInvitations를 페이지 단위로 반복 호출하여 해당 대시보드에 이미 등록된 모든 초대 이메일을 수집하고, SetData로 보관했습니당
- 폼 제출 전에 입력 이메일을 이 Set에 조회해서 중복이면 “이미 초대한 이메일입니다.” 에러를 띄우고 API 호출을 차단합니다.
- 성공 시에도 해당 이메일을 Set에 추가해서 즉시 다시 보내지 못하도록 했고, 서버 데이터를 기준으로 하므로 다른 브라우저나 세션에서도 동일하게 동작하는 것을 확인했습니다!

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
