### PR TITLE
[Fix/#260] 카드 이미지 드래그 안되게 처리

### DIFF
--- a/src/features/cards/components/card-list/card/index.tsx
+++ b/src/features/cards/components/card-list/card/index.tsx
@@ -82,8 +82,7 @@ function Card({ card }: CardProps) {
                 src={imageUrl}
                 alt={title}
                 className="w-full"
-                draggable="false"
-                onDragStart={(event) => event.preventDefault()}
+                draggable={false}
               />
             </figure>
           )}


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #260 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 카드에 표시되는 이미지에 draggable="false"를 걸고 onDragStart에서 event.preventDefault()를 호출해 이미지를 드래그해서 선택되지 않도록 구현했습니당
- 이미지가 선택되는 대신 카드 전체를 드래그하는 UX로 유지돼 작업 흐름이 방해되지 않도록 수정했습니다

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
