### PR TITLE
[Fix/#236] 할 일 카드 모달 내용 입력 후 조회할 때도 엔터 반영 

### DIFF
--- a/src/features/cards/components/task-modal/task-content/index.tsx
+++ b/src/features/cards/components/task-modal/task-content/index.tsx
@@ -2,8 +2,10 @@ import type { TaskContentProps } from '@/features/cards/components/task-modal/ta
 
 function TaskContent({ description, title, imageUrl }: TaskContentProps) {
   return (
-    <div className="pb-2 wrap-anywhere lg:pb-0">
-      <p className="typo-md-regular text-black">{description}</p>
+    <div className="pb-2 lg:pb-0">
+      <p className="typo-md-regular wrap-anywhere whitespace-pre-wrap text-black">
+        {description}
+      </p>
       {imageUrl && (
         <article className="mt-8 overflow-hidden rounded-md md:mt-4">
           <img src={imageUrl} alt={title} className="w-full max-w-110" />


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #236 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 할 일 카드 내용 입력 후 조회할 때도 엔터가 반영 되도록 CSS 수정
- `wrap-anywhere` 클래스는 `p` 태그로 위치 변경

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

Tailwind V4 최신 기준에 맞는 클래스 적용했습니다