### PR TITLE
[Fix/#272] 담당자 삭제 후 카드/수정 모달 동기화

### DIFF
--- a/src/features/cards/components/card-list/card/index.tsx
+++ b/src/features/cards/components/card-list/card/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { CardProps } from '@/features/cards/components/card-list/card/card.types';
 import { TaskModal } from '@/features/cards/components/task-modal';
 import { IcCalendar } from '@/shared/assets/icons';
@@ -15,12 +15,15 @@ function Card({ card }: CardProps) {
   const { isOpen, openModal, closeModal } = useModal();
   const preventModalOnClickRef = useRef(false);
   const dragBlockAnimationRef = useRef<number | null>(null);
+  const [currentCard, setCurrentCard] = useState(card);
 
   const { members, totalCount } = useDashboardMembersContextOrDefault();
-  const draggableId = card ? `card-${card.id}` : 'card-placeholder';
+  const draggableId = currentCard
+    ? `card-${currentCard.id}`
+    : 'card-placeholder';
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: draggableId,
-    data: card,
+    data: currentCard,
   });
 
   useEffect(() => {
@@ -45,11 +48,11 @@ function Card({ card }: CardProps) {
     };
   }, [isDragging]);
 
-  if (!card) {
+  if (!currentCard) {
     return null;
   }
 
-  const { imageUrl, title, tags, dueDate, assignee } = card;
+  const { imageUrl, title, tags, dueDate, assignee } = currentCard;
   const isFullList = totalCount > 0 && members.length >= totalCount;
   const assigneeId = assignee?.userId ?? null;
   const shouldDisplayAssignee =
@@ -134,7 +137,12 @@ function Card({ card }: CardProps) {
           </section>
         </div>
       </article>
-      <TaskModal isOpen={isOpen} closeModal={closeModal} card={card} />
+      <TaskModal
+        isOpen={isOpen}
+        closeModal={closeModal}
+        card={currentCard}
+        onCardUpdated={setCurrentCard}
+      />
     </>
   );
 }

--- a/src/features/cards/components/task-modal/index.tsx
+++ b/src/features/cards/components/task-modal/index.tsx
@@ -13,7 +13,12 @@ import { delCard } from '@/features/cards/apis/cards';
 import { MODAL_CLOSE_DELAY } from '@/shared/constants/modal.constants';
 import { useCardRefetchContext } from '@/features/cards/hooks/useCardRefetchContext';
 
-function TaskModal({ isOpen, closeModal, card }: TaskModalProps) {
+function TaskModal({
+  isOpen,
+  closeModal,
+  card,
+  onCardUpdated,
+}: TaskModalProps) {
   const { refetch } = useCardRefetchContext();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const {
@@ -120,6 +125,7 @@ function TaskModal({ isOpen, closeModal, card }: TaskModalProps) {
         isOpen={isEditModalOpen}
         onClose={handleCloseEditModal}
         card={card}
+        onCardUpdated={onCardUpdated}
       />
       <DeleteModal
         isOpen={isDeleteModalOpen}

--- a/src/features/cards/components/task-modal/taskModal.types.ts
+++ b/src/features/cards/components/task-modal/taskModal.types.ts
@@ -4,4 +4,5 @@ export type TaskModalProps = {
   isOpen: boolean;
   closeModal: () => void;
   card: Card;
+  onCardUpdated?: (card: Card) => void;
 };

--- a/src/features/cards/components/todo-edit-modal/index.tsx
+++ b/src/features/cards/components/todo-edit-modal/index.tsx
@@ -35,6 +35,7 @@ function TodoEditModalContent({
   onClose,
   card,
   dashboardId,
+  onCardUpdated,
 }: TodoEditModalProps & { dashboardId: number }) {
   const {
     selectedColumnId,
@@ -141,8 +142,9 @@ function TodoEditModalContent({
       imageUrl,
     };
 
-    const isUpdated = await handleUpdateCard(payload, card.columnId);
-    if (isUpdated) {
+    const updatedCard = await handleUpdateCard(payload, card.columnId);
+    if (updatedCard) {
+      onCardUpdated?.(updatedCard);
       onClose();
     }
   };

--- a/src/features/cards/components/todo-edit-modal/todoEditModal.types.ts
+++ b/src/features/cards/components/todo-edit-modal/todoEditModal.types.ts
@@ -4,4 +4,5 @@ export type TodoEditModalProps = {
   isOpen: boolean;
   onClose: () => void;
   card: Card;
+  onCardUpdated?: (card: Card) => void;
 };

--- a/src/features/cards/hooks/useTodoEditForm.ts
+++ b/src/features/cards/hooks/useTodoEditForm.ts
@@ -32,7 +32,7 @@ export function useTodoEditForm({ card }: UseTodoEditFormParams) {
       setSubmissionError(null);
 
       try {
-        await updateCard(cardId, payload);
+        const updatedCard = await updateCard(cardId, payload);
         refetch();
         window.dispatchEvent(
           new CustomEvent(CARD_EVENTS.LIST_CHANGE, {
@@ -42,14 +42,14 @@ export function useTodoEditForm({ card }: UseTodoEditFormParams) {
             },
           })
         );
-        return true;
+        return updatedCard;
       } catch (error) {
         const message =
           error instanceof Error
             ? error.message
             : '카드 수정을 실패했습니다. 다시 시도해 주세요.';
         setSubmissionError(message);
-        return false;
+        return null;
       } finally {
         setIsSubmitting(false);
       }


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #272

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 카드 컴포넌트는 useState로 현재 카드를 유지하고
- 수정 모달(TodoEditModal)이 반환한 최신 Card 객체를 받아 즉시 UI에 반영하도록 했습니다. 
- TaskModal/useTodoEditForm도 이 흐름에 맞춰 카드 수정 후 리스트와 모달이 동기화되도록 수정했습니다.

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
