### PR TITLE
[Fix/#297] 페이지 이동 시 스크롤이 최상단으로 초기화되지 않는 버그 수정

### DIFF
--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -11,10 +11,12 @@ import MyDashboardPage from '@/pages/my-dashboard';
 import MyPage from '@/pages/my';
 import NotFoundPage from '@/pages/not-found';
 import SignupPage from '@/pages/signup';
+import ScrollToTop from '@/shared/components/scroll-to-top';
 
 function Router() {
   return (
     <BrowserRouter>
+      <ScrollToTop />
       <Routes>
         <Route element={<PublicRoute />}>
           <Route path="/" element={<MainPage />} />

--- a/src/features/dashboards/components/layout/index.tsx
+++ b/src/features/dashboards/components/layout/index.tsx
@@ -191,7 +191,7 @@ export default function DashboardLayout() {
             memberLoadError={memberLoadError ?? ''}
             onProfileClick={handleNavigateMyPage}
           />
-          <main className="flex-1 overflow-auto">
+          <main id="main-scroll-area" className="flex-1 overflow-auto">
             <Outlet />
           </main>
         </div>

--- a/src/shared/components/scroll-to-top/index.tsx
+++ b/src/shared/components/scroll-to-top/index.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * 라우트(경로) 이동 시 스크롤을 최상단으로 초기화하는 공통 컴포넌트입니다.
+ */
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    const scrollContainer = document.getElementById('main-scroll-area');
+    if (scrollContainer) {
+      scrollContainer.scrollTo(0, 0);
+    } else {
+      window.scrollTo(0, 0);
+    }
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #297 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

페이지 이동 시 스크롤이 최상단으로 가도록 `ScrollToTop` 추가 후 적용

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
