### PR TITLE
[Fix/#302] 대시보드 이름 또는 색상 변경시에만 '변경' 버튼 활성화 되도록 수정

### DIFF
--- a/src/features/dashboards/components/name-section/index.tsx
+++ b/src/features/dashboards/components/name-section/index.tsx
@@ -99,6 +99,8 @@ export default function NameSection() {
 
       if (result) {
         setDashboardTitle(result.title);
+        setTitle(result.title);
+        setOriginalColor(selectedColor);
         dispatchDashboardTitleChangeEvent({ title: result.title });
       }
     } catch {


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #302 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 대시보드 이름 또는 색상을 변경했을 경우에만 변경 버튼이 활성화 되어있고, 변경이 없는 상태일 경우 disabled 처리되도록 수정
> <img width="593" height="331" alt="image" src="https://github.com/user-attachments/assets/79498388-859b-4c0f-ac74-dc8374fff3b2" />


### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
