### PR TITLE
[Fix/#304] 모바일 반응형에서 헤더 프로필 이미지 양쪽 여백 동일하게 표시되도록 수정

### DIFF
--- a/src/features/dashboards/components/layout/dashboard-header/index.tsx
+++ b/src/features/dashboards/components/layout/dashboard-header/index.tsx
@@ -122,7 +122,7 @@ export default function Header({
         {/* 유저 프로필 - 이름은 모바일에서 숨김 */}
         <button
           type="button"
-          className="cursor-pointer border-l border-gray-200 px-3 md:pl-6"
+          className="cursor-pointer border-l border-gray-200 px-3 md:pr-0 md:pl-6"
           onClick={onProfileClick}
         >
           {userProfile && (


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #304 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 모바일 반응형에서 헤더 프로필이미지(원형) 양쪽 여백 동일하게 표시되도록 수정
> <img width="426" height="135" alt="image" src="https://github.com/user-attachments/assets/13319edd-3dae-4b30-bfa0-207bfc8c58ff" />

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
