### PR TITLE
[Feat/#316] 회원가입 페이지 토스트 적용

### DIFF
--- a/src/features/auth/hooks/useSignup.ts
+++ b/src/features/auth/hooks/useSignup.ts
@@ -12,11 +12,9 @@ export function useSignup() {
   const navigate = useNavigate();
   const { showToast } = useToast();
   const [emailApiError, setEmailApiError] = useState('');
-  const [submitError, setSubmitError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const resetEmailApiError = () => setEmailApiError('');
-  const resetSubmitError = () => setSubmitError('');
 
   const isInvalidSignupState = ({
     password,
@@ -51,7 +49,6 @@ export function useSignup() {
 
     try {
       setIsSubmitting(true);
-      resetSubmitError();
       await signup({
         nickname: nickname.trim(),
         email: email.trim(),
@@ -72,11 +69,11 @@ export function useSignup() {
         return;
       }
 
-      setSubmitError(getSignupErrorMessage(error));
+      const errorMessage = getSignupErrorMessage(error);
       showToast({
         theme: 'error',
         title: '회원가입 실패',
-        message: getSignupErrorMessage(error),
+        message: errorMessage,
       });
     } finally {
       setIsSubmitting(false);
@@ -85,10 +82,8 @@ export function useSignup() {
 
   return {
     emailApiError,
-    submitError,
     isSubmitting,
     resetEmailApiError,
-    resetSubmitError,
     handleSignup,
   };
 }

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -8,14 +8,8 @@ import Input from '@/shared/components/input';
 import SignupAgreement from '@/pages/signup/components/signup-agreement';
 
 function SignupPage() {
-  const {
-    emailApiError,
-    submitError,
-    isSubmitting,
-    resetEmailApiError,
-    resetSubmitError,
-    handleSignup,
-  } = useSignup();
+  const { emailApiError, isSubmitting, resetEmailApiError, handleSignup } =
+    useSignup();
   const {
     nicknameField,
     emailField,
@@ -36,8 +30,6 @@ function SignupPage() {
     isPasswordConfirmIncluded: true,
     isAgreementIncluded: true,
     onEmailChange: resetEmailApiError,
-    onPasswordChange: resetSubmitError,
-    onPasswordConfirmChange: resetSubmitError,
   });
   const isDisabled = isSubmitting || isSubmitDisabled;
 
@@ -101,9 +93,6 @@ function SignupPage() {
           isChecked={isAgreementChecked}
           onChange={setIsAgreementChecked}
         />
-        {submitError && (
-          <p className="typo-md-regular text-error">{submitError}</p>
-        )}
         <Button
           theme="primary"
           size="md"


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #316 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 회원가입 페이지 성공 토스트 및 에러 토스트 적용
- 하지만 중복 이메일 에러의 경우, input 아래로 나오는 에러메세지가 더 자연스럽다고 느껴서 input 에러로 유지했습니당

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
