### PR TITLE
[Refactor/#322] 구성원 삭제 시 토스트 적용

### DIFF
--- a/src/features/members/components/members-section/index.tsx
+++ b/src/features/members/components/members-section/index.tsx
@@ -4,7 +4,7 @@ import NavigationButtons from '@/shared/components/page-indicator/navigation-but
 import Title from '@/shared/components/title';
 import UserProfile from '@/shared/components/user-profile';
 import DeleteModal from '@/shared/components/modal/delete-modal';
-import { useEffect, useState, useContext } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import type { Member } from '@/features/members/apis/members.types';
 import {
@@ -14,7 +14,7 @@ import {
 } from '@/features/members/apis/members';
 import { usePagination } from '@/shared/hooks/usePagination';
 import { dispatchMemberListChangeEvent } from '@/features/dashboards/utils/dashboardEvents';
-import { ToastContext } from '@/shared/context/toast/toastContext';
+import { useToast } from '@/shared/hooks/useToast';
 
 export default function MembersSection() {
   // URL에서 dashboardId 가져오기
@@ -33,12 +33,12 @@ export default function MembersSection() {
   const [selectedMemberId, setSelectedMemberId] = useState<number | null>(null);
 
   const [isDeleting, setIsDeleting] = useState(false);
-
+  const { showToast } = useToast();
   const handleCloseDeleteModal = () => {
     setIsDeleteModalOpen(false);
     setSelectedMemberId(null);
   };
-  const { showToast } = useContext(ToastContext)!;
+
   const handleConfirmDelete = async () => {
     if (!selectedMemberId || !dashboardId) return;
 
@@ -46,7 +46,18 @@ export default function MembersSection() {
 
     try {
       await deleteMember(selectedMemberId);
+    } catch {
+      showToast({
+        theme: 'error',
+        title: '구성원 삭제 실패',
+        message: '구성원 삭제에 실패했습니다.',
+      });
+      setIsDeleting(false);
+      return; // 삭제 실패 시 여기서 끝
+    }
 
+    // 삭제 성공 후 목록 갱신 (별도 try-catch)
+    try {
       const isLastItemOnPage = members.length === 1;
       const shouldGoBack = isLastItemOnPage && currentPage > 1;
 
@@ -59,24 +70,23 @@ export default function MembersSection() {
           syncTotalCount(data.totalCount, MEMBERS_SIZE);
         }
       }
-
-      dispatchMemberListChangeEvent();
-      handleCloseDeleteModal();
-
-      showToast({
-        theme: 'success',
-        title: '구성원 삭제 완료',
-        message: '구성원이 삭제되었습니다.',
-      });
     } catch {
       showToast({
-        theme: 'error',
-        title: '구성원 삭제 실패',
-        message: '구성원 삭제에 실패했습니다.',
+        theme: 'warning',
+        title: '구성원 목록 갱신 실패',
+        message: '목록 갱신에 실패했습니다. 새로고침해주세요.',
       });
-    } finally {
-      setIsDeleting(false);
     }
+
+    dispatchMemberListChangeEvent();
+    handleCloseDeleteModal();
+    setIsDeleting(false);
+
+    showToast({
+      theme: 'success',
+      title: '구성원 삭제 성공',
+      message: '구성원이 삭제되었습니다.',
+    });
   };
 
   // 구성원 목록 API 호출


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #324 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 구성원 삭제 성공 및 실패 시 토스트 적용
> <img width="559" height="157" alt="image" src="https://github.com/user-attachments/assets/2ccb86b1-46c6-4216-91bb-e78dee151be4" />


### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
