### PR TITLE
[Fix/#331] 할 일 제목 영어/숫자로 길게 적을때 튀어 나오는 문제 해결

### DIFF
--- a/src/features/cards/components/card-list/card/index.tsx
+++ b/src/features/cards/components/card-list/card/index.tsx
@@ -111,7 +111,7 @@ function Card({ card }: CardProps) {
                 size="md"
                 weight="medium"
                 color="text-black-200"
-                className="md:typo-lg-medium"
+                className="md:typo-lg-medium wrap-anywhere"
               >
                 {title}
               </Title>

--- a/src/shared/components/modal/modal-header/index.tsx
+++ b/src/shared/components/modal/modal-header/index.tsx
@@ -50,7 +50,7 @@ function ModalHeader({
       )}
       {...props}
     >
-      <h2 className="typo-xl-bold md:typo-2xl-bold text-black-200 w-full wrap-anywhere">
+      <h2 className="typo-xl-bold md:typo-2xl-bold text-black-200 min-w-0 flex-1 wrap-anywhere">
         {title}
       </h2>
       {(hasMenuIcon || hasCloseIcon) && (

--- a/src/shared/components/modal/modal-header/index.tsx
+++ b/src/shared/components/modal/modal-header/index.tsx
@@ -50,7 +50,7 @@ function ModalHeader({
       )}
       {...props}
     >
-      <h2 className="typo-xl-bold md:typo-2xl-bold text-black-200 w-full">
+      <h2 className="typo-xl-bold md:typo-2xl-bold text-black-200 w-full wrap-anywhere">
         {title}
       </h2>
       {(hasMenuIcon || hasCloseIcon) && (


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #331 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

카드 제목 및 모달 내 제목 부분에 `wrap-anywhere` 적용
[wrap-anywhere 공식 문서](https://tailwindcss.com/docs/overflow-wrap#wrapping-anywhere)

### 스크린샷 (선택)

<img width="221" height="846" alt="image" src="https://github.com/user-attachments/assets/92e150c9-4783-47e7-ae1d-7901b06bc4e8" />

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
